### PR TITLE
Added prefetch size to rabbit qos method, because it crash when sending null 

### DIFF
--- a/src/Backend/AMQPBackend.php
+++ b/src/Backend/AMQPBackend.php
@@ -78,6 +78,11 @@ class AMQPBackend implements BackendInterface
      * @var int|null
      */
     private $prefetchCount;
+    
+    /**
+     * @var int|null
+     */
+    private $prefetchSize;
 
     /**
      * @var AmqpConsumer
@@ -93,7 +98,7 @@ class AMQPBackend implements BackendInterface
      * @param string   $deadLetterRoutingKey
      * @param int|null $ttl
      */
-    public function __construct($exchange, $queue, $recover, $key, $deadLetterExchange = null, $deadLetterRoutingKey = null, $ttl = null, $prefetchCount = null)
+    public function __construct($exchange, $queue, $recover, $key, $deadLetterExchange = null, $deadLetterRoutingKey = null, $ttl = null, $prefetchCount = null, $prefetchSize = 0)
     {
         $this->exchange = $exchange;
         $this->queue = $queue;
@@ -103,6 +108,7 @@ class AMQPBackend implements BackendInterface
         $this->deadLetterRoutingKey = $deadLetterRoutingKey;
         $this->ttl = $ttl;
         $this->prefetchCount = $prefetchCount;
+        $this->prefetchSize = $prefetchSize;
     }
 
     public function setDispatcher(AMQPBackendDispatcher $dispatcher)
@@ -202,7 +208,7 @@ class AMQPBackend implements BackendInterface
         $context = $this->getContext();
 
         if (null !== $this->prefetchCount) {
-            $context->setQos(null, $this->prefetchCount, false);
+            $context->setQos($this->prefetchSize, $this->prefetchCount, false);
         }
 
         $this->consumer = $this->getContext()->createConsumer($this->getContext()->createQueue($this->queue));

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -248,7 +248,13 @@ Only used by RabbitMQ
 
 Defines the number of messages which will be delivered to the customer at a time.
 EOF;
+        $prefetchSizeInfo = <<<'EOF'
+Only used by RabbitMQ
 
+Defines the prefetch window size in octets.
+
+The server will send a message in advance if it is equal to or smaller in size than the available prefetch size (and also falls into other prefetch limits). May be set to zero, meaning "no specific limit", although other prefetch limits may still apply.
+EOF;
         $typesInfo = <<<'EOF'
 Only used by Doctrine
 
@@ -297,6 +303,12 @@ EOF;
                 ->end()
                 ->integerNode('prefetch_count')
                     ->info($prefetchCountInfo)
+                    ->min(0)
+                    ->max(65535)
+                    ->defaultValue(null)
+                ->end()
+                ->integerNode('prefetch_size')
+                    ->info($prefetchSizeInfo)
                     ->min(0)
                     ->max(65535)
                     ->defaultValue(null)

--- a/src/DependencyInjection/SonataNotificationExtension.php
+++ b/src/DependencyInjection/SonataNotificationExtension.php
@@ -315,6 +315,7 @@ class SonataNotificationExtension extends Extension
                 'dead_letter_routing_key' => null,
                 'ttl' => null,
                 'prefetch_count' => null,
+                'prefetch_size' => 0
             ]];
         }
 
@@ -362,7 +363,8 @@ class SonataNotificationExtension extends Extension
                 $queue['dead_letter_exchange'],
                 $queue['dead_letter_routing_key'],
                 $queue['ttl'],
-                $queue['prefetch_count']
+                $queue['prefetch_count'],
+                $queue['prefetch_size']
             );
 
             $amqBackends[$pos] = [


### PR DESCRIPTION
added prefetch size so it doesnt crash when calling               $context->setQos(null, $this->prefetchCount, false);
 because that param must be and integer and not null

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNotificationBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataNotificationBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
